### PR TITLE
Docker-ised and Vagrant-ised version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,11 @@ node_modules
 
 # Config file
 config.json
+
+# Eclipse project file
+.project
+
+# Vagrant configuration and runtime files
+vagrant-config.rb
+.vagrant-ppshorizon1423
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:6-onbuild

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require "json"
+require "./vagrant-config.rb"
+
+Vagrant.configure(2) do |config|
+  
+  app_config = JSON.parse(File.read("config.json"))
+  
+  config.vm.box = "ubuntu/wily64"
+  
+  config.vm.network "private_network", ip: DevEnv::IP
+
+  config.vm.provision "docker" do |d|
+  
+  	d.pull_images "tutum/mongodb"
+    
+    d.build_image "/vagrant",
+      args: "-t databox-app-server"
+      
+    d.run "tutum/mongodb",
+      auto_assign_name: false,
+      args: "--name databox-app-server-mongodb \
+        -e MONGODB_USER=\"#{app_config["mongodb"]["user"]}\" \
+        -e MONGODB_PASS=\"#{app_config["mongodb"]["pass"]}\" \
+        -e MONGODB_DATABASE=\"#{app_config["mongodb"]["db"]}\""
+      
+    d.run "databox-app-server",
+      auto_assign_name: false,
+      args: "--name databox-app-server \
+      	--link databox-app-server-mongodb:mongodb \
+      	-p 0.0.0.0:#{DevEnv::PORT}:#{DevEnv::PORT} \
+      	-e PORT=#{DevEnv::PORT}"
+    
+  end
+  
+end

--- a/config-template.json
+++ b/config-template.json
@@ -2,5 +2,12 @@
 	"recaptcha": {
 		"publicKey": "",
 		"privateKey": ""
+	},
+	"mongodb": {
+		"host": "",
+		"port": "",
+		"user": "",
+		"pass": "",
+		"db": ""
 	}
 }

--- a/db.ls
+++ b/db.ls
@@ -1,9 +1,9 @@
-require! mongodb
+require! { mongodb, './config.json' }
 
 _db = null
 
 connect = (callback) !->
-  err, db <-! mongodb.MongoClient.connect 'mongodb://localhost:27017/datashop'
+  err, db <-! mongodb.MongoClient.connect ('mongodb://' + config.mongodb.user + ':' + config.mongodb.pass + '@' + config.mongodb.host + ':' + config.mongodb.port + '/' + config.mongodb.db)
   if err then throw err
   _db := db
   callback db

--- a/server.ls
+++ b/server.ls
@@ -33,7 +33,7 @@ app.set 'view engine' \jade
 
 app.get \/ (req, res) !->
   unless req.session.user?
-    res.render \login
+    res.render \login { config: config }
     return
 
   res.render \dashboard { user: req.session.user }

--- a/vagrant-config.rb.example
+++ b/vagrant-config.rb.example
@@ -1,0 +1,6 @@
+module DevEnv
+  # Configure a static IP for the Vagrant machine
+  IP = "192.168.101.10"
+  # Configure a port for the app server to run on
+  PORT = "8080"
+end

--- a/views/login.jade
+++ b/views/login.jade
@@ -39,7 +39,7 @@ html
 						.form-group
 							input.form-control#pass-reg-input(type='password', placeholder='Password')
 						.form-group
-							.g-recaptcha(data-sitekey='6LchkBkTAAAAAAwEYuHZBvZbywEeCP1eb_xRbqJZ')
+							.g-recaptcha(data-sitekey=config.recaptcha.publicKey)
 					.modal-footer
 						button.btn.btn-primary#register-button(type='button', data-loading-text='Registering...') Register
 


### PR DESCRIPTION
Added support for running as a Docker application. Hardcoded values
for MongoDB server connection and ReCaptcha keys are now user
configurable in config.json.
Also added a Vagrant file for quickly running in dev environments,
this requires you to rename vagrant-config.rb.example to
vagrant-config.rb and change the IP and PORT values. All other configuration
is read from config.json.